### PR TITLE
Add Various Inputs

### DIFF
--- a/BaseController/BaseController.cs
+++ b/BaseController/BaseController.cs
@@ -8,22 +8,19 @@ using UnityEngine;
  */
 
 public class BaseController : MonoBehaviour, IBaseEntity {
-    public int t;
+    Bitfield m_bfButtons;
 
     /**
      * Unity method
      * Called on game start
      */
 
-    void Start() { t = 0; }
+    void Start() { m_bfButtons = new Bitfield(); }
 
     /**
      * Unity method
      * Called on each update frame
      */
 
-    void Update() {
-        Debug.Log("t = " + t);
-        t = t + 1;
-    }
+    void Update() {}
 }

--- a/BaseController/BaseController.cs
+++ b/BaseController/BaseController.cs
@@ -8,19 +8,23 @@ using UnityEngine;
  */
 
 public class BaseController : MonoBehaviour, IBaseEntity {
-    Bitfield m_bfButtons;
 
     /**
      * Unity method
      * Called on game start
      */
 
-    void Start() { m_bfButtons = new Bitfield(); }
+    void Start() {}
 
     /**
      * Unity method
      * Called on each update frame
      */
 
-    void Update() {}
+    void Update() {
+        if (BaseInput.isTrigger()) { Debug.Log("Trigger pressed"); }
+        if (BaseInput.isGrip()) { Debug.Log("Grip pressed"); }
+        if (BaseInput.isPrimary()) { Debug.Log("Primary pressed"); }
+        if (BaseInput.isSecondary()) { Debug.Log("Secondary pressed"); }
+    }
 }

--- a/System/BaseInput.cs
+++ b/System/BaseInput.cs
@@ -1,0 +1,52 @@
+/* using System.Collections; */
+/* using System.Collections.Generic; */
+using UnityEngine;
+
+/**
+ * BaseInput defines all input getters for the purposes of virtual reality.
+ * All input-related events should be monitored in this class.
+ */
+
+/*
+ * How to add a new input:
+ *
+ * 1. Create a boolean getter using the format is[Key](),
+ *    which returns true if the input is pressed and false otherwise
+ * 2.
+ */
+
+public static class BaseInput {
+    public static bool isTrigger() {
+        /* TODO motion controller input */
+        return Input.GetKey(KeyCode.T) || Input.GetMouseButton(0);
+    }
+
+    public static bool isGrip() {
+        /* TODO motion controller input */
+        return Input.GetKey(KeyCode.G);
+    }
+
+    public static bool isA() {
+        /* TODO motion controller input */
+        return Input.GetKey(KeyCode.A);
+    }
+
+    public static bool isB() {
+        /* TODO motion controller input */
+        return Input.GetKey(KeyCode.B);
+    }
+
+    public static bool isX() {
+        /* TODO motion controller input */
+        return Input.GetKey(KeyCode.X);
+    }
+
+    public static bool isY() {
+        /* TODO motion controller input */
+        return Input.GetKey(KeyCode.Y);
+    }
+
+    public static bool isPrimary() { return isA() || isB(); }
+
+    public static bool isSecondary() { return isX() || isY(); }
+}

--- a/System/Bitfield.cs
+++ b/System/Bitfield.cs
@@ -1,0 +1,31 @@
+/**
+ * A bitfield is an integer value which holds flags in each bit.
+ * Each flag corresponds to a unique boolean value.
+ */
+
+public class Bitfield {
+    private ulong m_bf;
+    public Bitfield() { m_bf = 0; }
+
+    /**
+     * Static method to generate an unsigned numerical value bit shifted
+     * [shift] units, or a bitmask.
+     */
+    public static ulong mask(int shift) { return ((ulong) 1) << shift; }
+
+    /**
+     * Applies a bitmask [mask] to the bitfield.
+     */
+    public void apply(ulong mask) { m_bf |= mask; }
+
+    /**
+     * Returns true if the bitfield has the
+     * bitmask (flag) [mask] enabled.
+     */
+    public bool has(ulong mask) { return m_bf == (m_bf | mask); }
+
+    /**
+     * Removes a bitmask [mask] from the bitfield.
+     */
+    public void remove(ulong mask) { m_bf &= ~mask; }
+}

--- a/System/Bitfield.cs
+++ b/System/Bitfield.cs
@@ -28,4 +28,10 @@ public class Bitfield {
      * Removes a bitmask [mask] from the bitfield.
      */
     public void remove(ulong mask) { m_bf &= ~mask; }
+
+    /**
+     * Returns the raw bitfield representation as an int. Should
+     * only be used for debugging purposes.
+     */
+    public int toInt() { return (int) m_bf; }
 }

--- a/System/Constants.cs
+++ b/System/Constants.cs
@@ -4,6 +4,7 @@
  */
 
 public static class Constants {
+    /* commonly used input identifiers */
     public const string MOUSE_X = "Mouse X";
     public const string MOUSE_Y = "Mouse Y";
 }

--- a/System/Utils.cs
+++ b/System/Utils.cs
@@ -1,17 +1,6 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 /**
  * Utils contains all commonly used utility functions or
  * members.
  */
 
-public class Utils {
-
-    /**
-     * Generates an unsigned numerical value bit shifted [shift] units,
-     * or a bitfield. Created primarily for use in bitmaps or flag objects.
-     */
-    public static ulong BF(int shift) { return ((ulong) 1) << shift; }
-}
+public class Utils {}

--- a/System/Utils.cs
+++ b/System/Utils.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/**
+ * Utils contains all commonly used utility functions or
+ * members.
+ */
+
+public class Utils {
+
+    /**
+     * Generates an unsigned numerical value bit shifted [shift] units,
+     * or a bitfield. Created primarily for use in bitmaps or flag objects.
+     */
+    public static ulong BF(int shift) { return ((ulong) 1) << shift; }
+}


### PR DESCRIPTION
To make our games actually playable, we need to monitor inputs.

Luckily, Unity makes it very easy to track and update events based on input. However, we want to have quick getter methods which better define the input we want (e.g. the `Trigger` input should refer to either the mouse `Button1` press, the letter `T` press, or the motion controller `Trigger` press).

I simply created a `BaseInput` class which creates a collection of static commonly defined input functions so we don't need to duplicate our input declarations in every file that requires input.

I additionally created a `Utils` class for future utility functions, and a `Bitfield` class for future flags in entities.